### PR TITLE
修复bug，使用#查询发电 时更准确判断是否有数据

### DIFF
--- a/main.py
+++ b/main.py
@@ -144,7 +144,7 @@ class AfdianPlugin(Star):
         """查询自己的收到的发电情况"""
         sponsor_user_ids = sponsor_user_ids or self.user_id
         sponsors = await self.client.query_sponsor(sponsor_user_ids=sponsor_user_ids)
-        if not sponsors.get("list"):  # 更准确地判断是否有数据
+        if not sponsors.get("list"):
             yield event.plain_result("未找到赞助记录")
             return
         sponsor_list = parse_sponsors(sponsors)

--- a/main.py
+++ b/main.py
@@ -144,7 +144,7 @@ class AfdianPlugin(Star):
         """查询自己的收到的发电情况"""
         sponsor_user_ids = sponsor_user_ids or self.user_id
         sponsors = await self.client.query_sponsor(sponsor_user_ids=sponsor_user_ids)
-        if not sponsors.get("list"):
+        if not sponsors.get("list", []):
             yield event.plain_result("未找到赞助记录")
             return
         sponsor_list = parse_sponsors(sponsors)


### PR DESCRIPTION
使用#查询发电 时更准确判断是否有数据，使得无发电记录时，指令响应为“未找到赞助记录”而不是空白图片，修改如下：
<img width="303" height="45" alt="20250805220054529" src="https://github.com/user-attachments/assets/c45162ab-4d9a-44ae-b1a0-08a57be95649" />
修改前：
<img width="828" height="127" alt="20250805220614051" src="https://github.com/user-attachments/assets/b59792c4-93d7-4c78-9258-9af0354070f3" />

修改后：
![7FFFBD41C1A223F36228DA1D2B0DD524](https://github.com/user-attachments/assets/e346a72a-7c2e-4593-892a-820cf0e033b0)

其余修改为ruff自动格式化换行，无影响

## Sourcery 总结

修复了赞助查询命令，使其能正确检测无记录情况并返回用户友好消息，同时应用 ruff 自动格式化并更新了命令文档字符串。

错误修复：
- 在 `query_sponsor` 中准确检测赞助记录的缺失，并用“未找到赞助记录”回应，而不是发送一张空白图片

改进：
- 应用 ruff 自动格式化以标准化换行符并删除多余的空行
- 优化 `query_order` 和 `query_sponsor` 命令的文档字符串，以提供更清晰的使用说明

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the sponsor query command to correctly detect when there are no records and return a user-friendly message, and apply ruff auto-formatting with updated command docstrings.

Bug Fixes:
- Accurately detect absence of sponsor records in query_sponsor and respond with "未找到赞助记录" instead of sending a blank image

Enhancements:
- Apply ruff auto-formatting to standardize line breaks and remove extra blank lines
- Refine command docstrings for query_order and query_sponsor for clearer usage descriptions

</details>