### PR TITLE
修改爱发电后台，修复订单查询

### DIFF
--- a/core/afdian_api.py
+++ b/core/afdian_api.py
@@ -14,7 +14,7 @@ class AfdianAPIClient:
         """
         self.user_id = user_id
         self.token = token
-        self.base_url = "https://afdian.com/api/open"
+        self.base_url = "https://ifdian.net/api/open"
         self.session = aiohttp.ClientSession()
 
     async def close(self):
@@ -105,7 +105,7 @@ class AfdianAPIClient:
         """
         price_str = f"{round(price, 2):.2f}"
         url = (
-            f"https://afdian.com/order/create?"
+            f"https://ifdian.net/order/create?"
             f"user_id={self.user_id}"
             f"&remark={remark}"
             f"&custom_price={price_str}"

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ class AfdianPlugin(Star):
         """
         查询自己的收到的发电情况
         """
-        sponsor_user_ids = sponsor_user_ids or self.user_id
+        
         sponsors = await self.client.query_sponsor(sponsor_user_ids=sponsor_user_ids)
         if not sponsors:
             yield event.plain_result("未找到该订单")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_afdian # 这是你的插件的唯一识别名。
 desc: 爱发电对接插件，接受用户打赏，实时推送订单情况  # 插件简短描述
 help: None
-version: v1.0.1 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.0.2 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_afdian # 插件的仓库地址


### PR DESCRIPTION
## Summary by Sourcery

更新爱发电（Afdian）集成以使用新的 ifdian.net 端点，并调整赞助者查询处理方式。

Bug 修复：
- 修复赞助者订单查询问题，不再覆盖传入的 `sponsor_user_ids` 参数。

增强内容：
- 将所有 Afdian API 和订单创建相关的 URL 从 afdian.com 切换为 ifdian.net。
- 将插件元数据版本提升至 v1.0.2，以反映更新后的 Afdian 集成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Afdian integration to use the new ifdian.net endpoints and adjust sponsor query handling.

Bug Fixes:
- Fix sponsor order query by no longer overriding the provided sponsor_user_ids parameter.

Enhancements:
- Switch all Afdian API and order creation URLs from afdian.com to ifdian.net.
- Bump plugin metadata version to v1.0.2 to reflect the updated Afdian integration.

</details>